### PR TITLE
add latest_actiivty_timestamp action and make api response available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    orbit_activities (0.0.2)
+    orbit_activities (0.1.0)
       http (~> 4.4)
       json (~> 2.5)
       rake (~> 13.0)
@@ -19,7 +19,7 @@ GEM
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.15.0)
+    ffi (1.15.3)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -29,7 +29,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http-parser (1.2.3)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ OrbitActivities::Request.new(
     body: # The custom activity object in JSON format, see Orbit API docs for reference
 )
 ```
+
+You can inspect the Orbit API response by appending `.response` to the end of the initialization method.
 #### Update an Activity
 
 To update an activity:
@@ -48,6 +50,8 @@ OrbitActivities::Request.new(
     body: # The custom activity object in JSON format, see Orbit API docs for reference
 )
 ```
+
+You can inspect the Orbit API response by appending `.response` to the end of the initialization method.
 #### Delete an Activity
 
 To delete an activity:
@@ -61,6 +65,8 @@ OrbitActivities::Request.new(
     member_id: # The ID of the member the activity is attached to
 )
 ```
+
+You can inspect the Orbit API response by appending `.response` to the end of the initialization method.
 #### List Activities
 
 To list activities:
@@ -71,7 +77,7 @@ OrbitActivities::Request.new(
     workspace_id: # Your Orbit workspace ID,
     action: "list_activities",
     filters: # Any filters on the request in JSON format, see Orbit API docs for reference
-)
+).response
 ```
 #### Get Specific Activity
 
@@ -83,7 +89,7 @@ OrbitActivities::Request.new(
     workspace_id: # Your Orbit workspace ID,
     action: "get_activity",
     activity_id: # The ID of the actiivity
-)
+).response
 ```
 #### Get Member Activities
 
@@ -97,7 +103,19 @@ OrbitActivities::Request.new(
     activity_id: # The ID of the actiivity,
     member_id: # The ID of the member,
     filters: # Any filters on the request in JSON format, see Orbit API docs for reference
-)
+).response
+```
+#### Get Latest Activity Timestamp for Activity Type
+
+To get the latest activity timestamp for a specific activity type:
+
+```ruby
+OrbitActivities::Request.new(
+    api_key: # Your Orbit API key,
+    workspace_id: # Your Orbit workspace ID,
+    action: "latest_activity_timestamp",
+    filters: { activity_type: # Activity type to search for, e.g. "custom:linkedin:comment" }
+).response
 ```
 
 For details on the data structures the Orbit API expects, refer to the [Orbit API Documentation](https://docs.orbit.love/reference).


### PR DESCRIPTION
In this pull request, we add a new action `latest_activity_timestamp` that returns the created at value for the latest activity in a workspace for a specific activity type.

We also make the API response available for inspection in all of the actions, including this new one.