### PR TITLE
handle rate limit error in post requests

### DIFF
--- a/lib/orbit_activities.rb
+++ b/lib/orbit_activities.rb
@@ -6,6 +6,9 @@ require_relative "orbit_activities/version"
 module OrbitActivities
   loader = Zeitwerk::Loader.new
   loader.tag = File.basename(__FILE__, ".rb")
+  loader.inflector.inflect({
+    'Http' => 'HTTP'
+  })
   loader.push_dir(__dir__)
   loader.setup
 end

--- a/lib/orbit_activities/http.rb
+++ b/lib/orbit_activities/http.rb
@@ -21,6 +21,12 @@ module OrbitActivities
 
       response = http.request(req)
 
+      if response.class == Net::HTTPTooManyRequests
+        puts "Reached rate limitation in API, retrying in 60 seconds..."
+        sleep(60)
+        response = http.request(req)
+      end
+
       validate_payload(response.body)
     end
 

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+require_relative "../lib/orbit_activities/http"
+
+RSpec.describe OrbitActivities::HTTP do
+  describe "#post" do
+    context "for a successful HTTP POST request" do
+      before(:each) do
+        http = double
+        allow(Net::HTTP).to receive(:start).and_yield http
+        allow(http).to receive(:request).with(an_instance_of(Net::HTTP::Post)).and_return(Net::HTTPCreated)
+        stub_request(:post, "https://api.example.com/example-request")
+        .with(
+        headers: { 'Authorization' => "Bearer abc123", 'Content-Type' => 'application/json', "User-Agent"=>"community-ruby-starfleet-orbit/#{OrbitActivities::VERSION}" },
+        body: "this is a sample request"
+        )
+        .to_return(
+            status: 200,
+            body: {
+                response: {
+                    code: 'SUCCESS'
+                }
+            }.to_json.to_s,
+            headers: {}
+        )
+      end
+
+      it "returns the API response message" do
+        expect(
+          OrbitActivities::HTTP.post(
+            url: "https://api.example.com/example-request",
+            user_agent: "community-ruby-starfleet-orbit/#{OrbitActivities::VERSION}",
+            api_key: "abc123",
+            body: "this is a sample request"
+          )
+        ).to eql("response" => {"code"=>"SUCCESS"})
+      end
+    end
+
+    context "for a rate limited POST request" do
+      before(:each) do
+        http = double
+        allow(Net::HTTP).to receive(:start).and_yield http
+        allow(http).to receive(:request).with(an_instance_of(Net::HTTP::Post)).and_return(Net::HTTPTooManyRequests)
+        stub_request(:post, "https://api.example.com/example-request")
+        .with(
+        headers: { 'Authorization' => "Bearer abc123", 'Content-Type' => 'application/json', "User-Agent"=>"community-ruby-starfleet-orbit/#{OrbitActivities::VERSION}" },
+        body: "this is a sample request"
+        )
+        .to_return(
+          {
+            status: 429,
+            body: {
+                response: {
+                    code: 'Throttled'
+                }
+            }.to_json.to_s,
+            headers: {}
+          },
+          {
+            status: 200,
+            body: {
+              response: {
+                code: 'SUCCESS'
+              }
+            }.to_json.to_s,
+            headers: {}
+          }
+        )
+      end
+
+      it "waits 60 seconds and tries again for a successful request" do
+        expect(OrbitActivities::HTTP).to receive(:sleep).with(60)
+        expect(
+          OrbitActivities::HTTP.post(
+            url: "https://api.example.com/example-request",
+            user_agent: "community-ruby-starfleet-orbit/#{OrbitActivities::VERSION}",
+            api_key: "abc123",
+            body: "this is a sample request"
+          )
+        ).to eql("response" => {"code"=>"SUCCESS"})
+      end
+    end
+  end
+end


### PR DESCRIPTION
This issue has come up a couple of times with highly active integrations, like Circle.

The PR checks if the response class is `Net::HTTPTooManyRequests`, and if so, sleeps for a full 60 seconds before retrying. The 60 seconds is conservative, as the [Orbit API rate limit](https://docs.orbit.love/reference/rate-limiting) refreshes per minute. It's possible it could require less than a minute for a specific request depending on the specificity of timing, but requiring 60 seconds ensures success the second time, regardless.